### PR TITLE
First step in making output changes in task-scheduler

### DIFF
--- a/change/@microsoft-task-scheduler-2020-06-03-16-21-41-output1.json
+++ b/change/@microsoft-task-scheduler-2020-06-03-16-21-41-output1.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "allow override of logger in task-scheduler",
+  "packageName": "@microsoft/task-scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-03T23:21:41.016Z"
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -124,6 +124,10 @@ export function createPipelineInternal(
   return pipeline;
 }
 
-export function createPipeline(graph: TopologicalGraph): Pipeline {
-  return createPipelineInternal(graph, defaultGlobals, new Map());
+export function createPipeline(
+  graph: TopologicalGraph,
+  options: Partial<Pick<Globals, "logger">> = {}
+): Pipeline {
+  const fullOptions: Globals = { ...defaultGlobals, ...options };
+  return createPipelineInternal(graph, fullOptions, new Map());
 }


### PR DESCRIPTION
Ideally, task-scheduler does not do anything with logging. It should provide information for the consumer about the tasks run instead. However, logging has been included so far. We change the API slightly in this PR to preserve `output.ts` while allowing consumers to override its behavior.