### PR TITLE
Exit override

### DIFF
--- a/change/@microsoft-task-scheduler-2020-06-05-08-44-02-exit-override.json
+++ b/change/@microsoft-task-scheduler-2020-06-05-08-44-02-exit-override.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding an override for exit() so consumers can handle the exits",
+  "packageName": "@microsoft/task-scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-05T15:44:02.501Z"
+}

--- a/change/@microsoft-task-scheduler-2020-06-05-08-44-02-exit-override.json
+++ b/change/@microsoft-task-scheduler-2020-06-05-08-44-02-exit-override.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "adding an override for exit() so consumers can handle the exits",
   "packageName": "@microsoft/task-scheduler",
   "email": "kchau@microsoft.com",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc && webpack",
+    "build": "tsc",
     "start": "tsc -w --preserveWatchOutput",
     "test": "jest",
     "lint": "eslint . --ext .ts",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "repository": "git@github.com:microsoft/task-scheduler.git",
   "license": "MIT",
   "author": "Vincent Bailly <vibailly@tuta.io>",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "tsc && webpack",
+    "start": "tsc -w --preserveWatchOutput",
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint --fix . --ext .ts",

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -126,7 +126,7 @@ export function createPipelineInternal(
 
 export function createPipeline(
   graph: TopologicalGraph,
-  options: Partial<Pick<Globals, "logger">> = {}
+  options: Partial<Pick<Globals, "logger" | "exit">> = {}
 ): Pipeline {
   const fullOptions: Globals = { ...defaultGlobals, ...options };
   return createPipelineInternal(graph, fullOptions, new Map());

--- a/src/runAndLog.ts
+++ b/src/runAndLog.ts
@@ -26,8 +26,11 @@ async function runAndCollectLogs(
 
     return { success, stdout: stdout.toString(), stderr: stderr.toString() };
   } catch (error) {
-    const exceptionMessage = globals.errorFormatter(error);
-    stderr.write(EOL + exceptionMessage);
+    if (error) {
+      const exceptionMessage = globals.errorFormatter(error);
+      stderr.write(EOL + exceptionMessage);
+    }
+
     return {
       success: false,
       stdout: stdout.toString(),


### PR DESCRIPTION
Adding a exit() override and a handling for error object to be undefined if the task function doesn't provide an error.