### PR TITLE
Every publish of this package will flip this to private if we do not set this up as public

### DIFF
--- a/change/@microsoft-task-scheduler-2020-06-05-09-30-30-master.json
+++ b/change/@microsoft-task-scheduler-2020-06-05-09-30-30-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding public access since this is microsoft scoped",
+  "packageName": "@microsoft/task-scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-05T16:30:30.496Z"
+}

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "tsc && webpack",
-    "start": "tsc -w --preserveWatchOutput",
-    "test": "jest",
+    "change": "beachball change",
+    "checkchange": "beachball check",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint --fix . --ext .ts",
     "release": "beachball publish -y",
-    "change": "beachball change",
-    "checkchange": "beachball check"
+    "start": "tsc -w --preserveWatchOutput",
+    "test": "jest"
   },
   "husky": {
     "hooks": {
@@ -52,5 +52,8 @@
     "typescript": "^3.8.3",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This package needs to be public to be consumable by others