### PR TITLE
Adds a targets only mode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
     "import/order": "warn",
   },
 };

--- a/change/@microsoft-task-scheduler-2020-07-13-14-40-47-targetsonly.json
+++ b/change/@microsoft-task-scheduler-2020-07-13-14-40-47-targetsonly.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adds a targets only mode",
+  "packageName": "@microsoft/task-scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-13T21:40:47.130Z"
+}

--- a/src/__tests__/generateTaskGraph.test.ts
+++ b/src/__tests__/generateTaskGraph.test.ts
@@ -1,5 +1,5 @@
 import { generateTaskGraph } from "../generateTaskGraph";
-import { Task, Tasks } from "../types";
+import { Tasks } from "../types";
 import { getPackageTaskFromId } from "../taskId";
 
 describe("generateTaskGraph", () => {

--- a/src/__tests__/generateTaskGraph.test.ts
+++ b/src/__tests__/generateTaskGraph.test.ts
@@ -1,0 +1,52 @@
+import { generateTaskGraph } from "../generateTaskGraph";
+import { Task, Tasks } from "../types";
+import { getPackageTaskFromId } from "../taskId";
+
+describe("generateTaskGraph", () => {
+  const graph = {
+    A: { location: "a", dependencies: ["B"] },
+    B: { location: "b", dependencies: [] },
+  };
+
+  test("targetOnly mode includes only tasks listed in targets array", async () => {
+    const scope = ["A", "B"];
+    const targets = ["test", "bundle"];
+    const tasks: Tasks = new Map([
+      [
+        "build",
+        {
+          name: "build",
+          run: () => Promise.resolve(true),
+          deps: [],
+          topoDeps: ["build"],
+        },
+      ],
+      [
+        "test",
+        {
+          name: "test",
+          run: () => Promise.resolve(true),
+          deps: [],
+          topoDeps: [],
+        },
+      ],
+      [
+        "bundle",
+        {
+          name: "bundle",
+          run: () => Promise.resolve(true),
+          deps: ["build"],
+          topoDeps: [],
+        },
+      ],
+    ]);
+
+    const taskGraph = generateTaskGraph(scope, targets, tasks, graph, true);
+    expect(taskGraph).toHaveLength(4);
+
+    // None of the "from" taskId should contain "build" task
+    expect(
+      !taskGraph.find((entry) => getPackageTaskFromId(entry[0])[1] === "build")
+    ).toBeTruthy();
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { EOL } from "os";
 import { Writable } from "stream";
-import { createPipelineInternal } from "./pipeline";
-import { Task, Globals } from "./publicInterfaces";
+import { createPipelineInternal } from "../pipeline";
+import { Task, Globals } from "../publicInterfaces";
 
 describe("task scheduling", () => {
   const graph = {

--- a/src/generateTaskGraph.ts
+++ b/src/generateTaskGraph.ts
@@ -5,7 +5,8 @@ export function generateTaskGraph(
   scope: string[],
   targets: string[],
   tasks: Tasks,
-  graph: TopologicalGraph
+  graph: TopologicalGraph,
+  targetsOnly: boolean
 ): PackageTaskDeps {
   const taskDeps: PackageTaskDeps = [];
 
@@ -26,6 +27,12 @@ export function generateTaskGraph(
     if (!visited.has(taskId) && tasks.has(taskName)) {
       visited.add(taskId);
       const task = tasks.get(taskName)!;
+
+      // If we're in targetsOnly mode, make sure none of the non-targets are filtered out of task.deps
+      task.deps = targetsOnly
+        ? task.deps?.filter((d) => targets.indexOf(d) > -1)
+        : task.deps;
+
       const toTaskId = getTaskId(pkg, taskName);
 
       const hasTopoDeps = task.topoDeps && task.topoDeps.length > 0;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -353,6 +353,7 @@ function getGlobals(stdoutAsStderr = false): TestingGlobals {
     errorFormatter(err: Error): string {
       return `stack trace for following error: ${err.message}`;
     },
+    targetsOnly: false,
   };
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -2,7 +2,7 @@ import pGraph from "p-graph";
 
 import { generateTaskGraph } from "./generateTaskGraph";
 import { outputResult } from "./output";
-import { Globals, Pipeline } from "./publicInterfaces";
+import { Globals, Pipeline, Options } from "./publicInterfaces";
 import { runAndLog } from "./runAndLog";
 import { getPackageTaskFromId } from "./taskId";
 import { PackageTasks, Task, Tasks, TopologicalGraph } from "./types";
@@ -18,6 +18,7 @@ const defaultGlobals: Globals = {
   errorFormatter(err: Error): string {
     return err.stack || err.message || err.toString();
   },
+  targetsOnly: false,
 };
 
 async function execute(
@@ -65,7 +66,8 @@ export function createPipelineInternal(
         targets.packages,
         targets.tasks,
         tasks,
-        graph
+        graph,
+        globals.targetsOnly
       );
       const failures: {
         task: string;
@@ -126,7 +128,7 @@ export function createPipelineInternal(
 
 export function createPipeline(
   graph: TopologicalGraph,
-  options: Partial<Pick<Globals, "logger" | "exit">> = {}
+  options: Options = {}
 ): Pipeline {
   const fullOptions: Globals = { ...defaultGlobals, ...options };
   return createPipelineInternal(graph, fullOptions, new Map());

--- a/src/publicInterfaces.ts
+++ b/src/publicInterfaces.ts
@@ -12,4 +12,7 @@ export type Globals = {
   cwd(): string;
   exit(int: number): void;
   errorFormatter(err: Error): string;
+  targetsOnly: boolean;
 };
+
+export type Options = Partial<Pick<Globals, "logger" | "exit" | "targetsOnly">>;


### PR DESCRIPTION
With a targets mode, we filter out "irrelevant" target tasks. This is a lot like scoping by package names but except for tasks.