### PR TITLE
Change priority API to be package specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ type Task = {
   /** dependencies across packages within the same topological graph (e.g. parent `build` -> child `build`) */
   topoDeps?: string[];
 
-  /** An optional priority for this task. When maxConcurrency is set on a pipeline, unblocked tasks with a higher priority will be scheduled before lower priority tasks. */
-  priority?: number;
+  /** An optional priority to set for packages that have this task. Unblocked tasks with a higher priority will be scheduled before lower priority tasks. */
+  priorities?: {
+    [packageName: string]: number;
+  };
 };
 ```
 

--- a/change/@microsoft-task-scheduler-2020-07-15-07-21-49-chrisgo-priority-2.json
+++ b/change/@microsoft-task-scheduler-2020-07-15-07-21-49-chrisgo-priority-2.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Change priority API to be package specific",
+  "packageName": "@microsoft/task-scheduler",
+  "email": "1581488+christiango@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-15T14:21:49.153Z"
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -88,7 +88,7 @@ export function createPipelineInternal(
             } else {
               const task = tasks.get(taskName)!;
               packageTasks.set(taskId, {
-                priority: task.priority,
+                priority: task.priorities && task.priorities[pkg],
                 run: () =>
                   execute(globals, graph, task, pkg, () => bail).catch(
                     (error: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,8 +27,10 @@ export type Task = {
   /** dependencies across packages within the same topological graph (e.g. parent `build` -> child `build`) */
   topoDeps?: string[];
 
-  /** An optional priority for this task. When maxConcurrency is set on a pipeline, unblocked tasks with a higher priority will be scheduled before lower priority tasks. */
-  priority?: number;
+  /** An optional priority to set for packages that have this task. Unblocked tasks with a higher priority will be scheduled before lower priority tasks. */
+  priorities?: {
+    [packageName: string]: number;
+  };
 };
 
 export interface PackageTask extends Task {


### PR DESCRIPTION
Turns out we want to make the priority API such that you can specify it for a task/package combination, this makes that change. Marked as minor even though this is breaking since we only just released priorities