### PR TITLE
export generateTaskGraph as well

### DIFF
--- a/change/@microsoft-task-scheduler-2020-08-13-10-01-36-generateTaskGraph.json
+++ b/change/@microsoft-task-scheduler-2020-08-13-10-01-36-generateTaskGraph.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "exposes generateTaskGraph as well so it can be used as a separate library util to examine the task graph",
+  "packageName": "@microsoft/task-scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-13T17:01:36.733Z"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { TopologicalGraph, Task, Pipeline } from "./publicInterfaces";
 export { createPipeline } from "./pipeline";
+export { generateTaskGraph } from "./generateTaskGraph";


### PR DESCRIPTION
This is good for building out tooling that will need access to the package-task graph (for visualization or to export for distributed build systems)