### PR TITLE
Adds a "addDeps()" API to manually add some dependencies in cases where tweaking is necessary

### DIFF
--- a/change/@microsoft-task-scheduler-2020-08-14-09-56-35-addDeps.json
+++ b/change/@microsoft-task-scheduler-2020-08-14-09-56-35-addDeps.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adds the ability to add an individual package task dependency",
+  "packageName": "@microsoft/task-scheduler",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-14T16:56:35.838Z"
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:microsoft/task-scheduler.git",
   "license": "MIT",
   "author": "Vincent Bailly <vibailly@tuta.io>",
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "tsc && webpack",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:microsoft/task-scheduler.git",
   "license": "MIT",
   "author": "Vincent Bailly <vibailly@tuta.io>",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "tsc && webpack",

--- a/src/__tests__/generateTaskGraph.test.ts
+++ b/src/__tests__/generateTaskGraph.test.ts
@@ -41,7 +41,7 @@ describe("generateTaskGraph", () => {
       ],
     ]);
 
-    const taskGraph = generateTaskGraph(scope, targets, tasks, graph, true);
+    const taskGraph = generateTaskGraph(scope, targets, tasks, graph, [], true);
     expect(taskGraph).toHaveLength(4);
 
     // None of the "from" taskId should contain "build" task

--- a/src/generateTaskGraph.ts
+++ b/src/generateTaskGraph.ts
@@ -12,8 +12,8 @@ export function generateTaskGraph(
   targets: string[],
   tasks: Tasks,
   graph: TopologicalGraph,
-  packageTaskDeps: PackageTaskDeps,
-  targetsOnly: boolean
+  packageTaskDeps: PackageTaskDeps = [],
+  targetsOnly: boolean = false
 ): PackageTaskDeps {
   const taskDeps: PackageTaskDeps = [];
 

--- a/src/generateTaskGraph.ts
+++ b/src/generateTaskGraph.ts
@@ -1,11 +1,18 @@
 import { getTaskId, getPackageTaskFromId } from "./taskId";
-import { TopologicalGraph, Tasks, TaskId, PackageTaskDeps } from "./types";
+import {
+  TopologicalGraph,
+  Tasks,
+  TaskId,
+  PackageTaskDeps,
+  PackageTask,
+} from "./types";
 
 export function generateTaskGraph(
   scope: string[],
   targets: string[],
   tasks: Tasks,
   graph: TopologicalGraph,
+  packageTaskDeps: PackageTaskDeps,
   targetsOnly: boolean
 ): PackageTaskDeps {
   const taskDeps: PackageTaskDeps = [];
@@ -65,6 +72,16 @@ export function generateTaskGraph(
         const fromTaskId = getTaskId(pkg, "");
         taskDeps.push([fromTaskId, toTaskId]);
       }
+    }
+  }
+
+  // After the automated taskDeps from graph traversal, add in the manually added ones
+  // Make sure these are unique by using a Set
+  const key = (entry: [TaskId, TaskId]) => `${entry[0]}###${entry[1]}`;
+  const taskDepsSet = new Set(taskDeps.map((entry) => key(entry)));
+  for (const entry of packageTaskDeps) {
+    if (!taskDepsSet.has(key(entry))) {
+      taskDeps.push(entry);
     }
   }
 

--- a/src/generateTaskGraph.ts
+++ b/src/generateTaskGraph.ts
@@ -7,7 +7,7 @@ export function generateTaskGraph(
   tasks: Tasks,
   graph: TopologicalGraph,
   packageTaskDeps: PackageTaskDeps = [],
-  targetsOnly: boolean = false
+  targetsOnly = false
 ): PackageTaskDeps {
   const taskDeps: PackageTaskDeps = [];
 

--- a/src/generateTaskGraph.ts
+++ b/src/generateTaskGraph.ts
@@ -1,11 +1,5 @@
 import { getTaskId, getPackageTaskFromId } from "./taskId";
-import {
-  TopologicalGraph,
-  Tasks,
-  TaskId,
-  PackageTaskDeps,
-  PackageTask,
-} from "./types";
+import { TopologicalGraph, Tasks, TaskId, PackageTaskDeps } from "./types";
 
 export function generateTaskGraph(
   scope: string[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
-export { TopologicalGraph, Task, Pipeline } from "./publicInterfaces";
+export {
+  TopologicalGraph,
+  Task,
+  Pipeline,
+  PackageTask,
+} from "./publicInterfaces";
 export { createPipeline } from "./pipeline";
 export { generateTaskGraph } from "./generateTaskGraph";
+export { getTaskId, getPackageTaskFromId } from "./taskId";

--- a/src/publicInterfaces.ts
+++ b/src/publicInterfaces.ts
@@ -1,9 +1,10 @@
-import { Task, Logger } from "./types";
+import { Task, Logger, PackageTask } from "./types";
 
 export { Task, TopologicalGraph, Tasks } from "./types";
 
 export type Pipeline = {
   addTask: (task: Task) => Pipeline;
+  addDep: (from: PackageTask, to: PackageTask) => Pipeline;
   go: (targets?: { packages?: string[]; tasks?: string[] }) => Promise<void>;
 };
 

--- a/src/publicInterfaces.ts
+++ b/src/publicInterfaces.ts
@@ -1,6 +1,6 @@
 import { Task, Logger, PackageTask } from "./types";
 
-export { Task, TopologicalGraph, Tasks } from "./types";
+export { Task, TopologicalGraph, Tasks, PackageTask } from "./types";
 
 export type Pipeline = {
   addTask: (task: Task) => Pipeline;

--- a/src/taskId.ts
+++ b/src/taskId.ts
@@ -1,6 +1,6 @@
 import { TaskId } from "./types";
 
-const DELIMITER = "###";
+const DELIMITER = ":";
 
 export function getTaskId(pkg: string, taskName: string): string {
   return `${pkg}${DELIMITER}${taskName}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,10 +33,7 @@ export type Task = {
   };
 };
 
-export interface PackageTask extends Task {
-  package: string;
-}
-
+export type PackageTask = { package: string; task: string };
 export type PackageTaskDeps = [string, string][];
 export type TaskId = string;
 


### PR DESCRIPTION
There are cases where the general "addTask()" and a knowledge of package topology cannot express every case. Sometimes it is necessary to add some package task to package task dependency (sometimes a test necesssarily needs to be run before a build of another package). It is indicative of something wrong with the monorepo, but it is sometimes needed to handle edge case (resource contention, etc).