### PR TITLE
fix: Declare p-graph as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run a sequence of steps across all the packages of a monorepo.
 - This tool does not assume any workspace/package manager so it can be used on any JavaScript repository.
 - The steps run on the main thread, sparing the cost of spawning one process per step. If parallelization is needed, the implementation of the steps can spawn processes.
 - This tool optimizes CI builds performance by avoiding unnecessary waiting (see example below).
-- This tool has no dependencies and is very small.
+- This tool is very small.
 - Its interface makes it easy to compose with other tools to get fancy pipelines (eg. parallelization, profiling, throttling...)
 - Running the tasks on the main node process allows for cross-step in-memory memoization
 
@@ -119,14 +119,14 @@ B: [-prepare-]           [------build------]                    [----test----][-
 This repo uses `beachball` for automated releases and semver. Please include a change file by running:
 
 ```
-$ yarn change
+yarn change
 ```
 
 ## CLA
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ yarn change
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ B: [-prepare-]           [------build------]                    [----test----][-
 This repo uses `beachball` for automated releases and semver. Please include a change file by running:
 
 ```
-yarn change
+$ yarn change
 ```
 
 ## CLA

--- a/change/@microsoft-task-scheduler-2020-10-05-19-38-42-update-p-graph.json
+++ b/change/@microsoft-task-scheduler-2020-10-05-19-38-42-update-p-graph.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: Declare p-graph as a dependency",
+  "packageName": "@microsoft/task-scheduler",
+  "email": "oliver.kuruma@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-05T17:38:42.914Z"
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
       "git add"
     ]
   },
+  "dependencies": {
+    "p-graph": "^1.0.2"
+  },
   "devDependencies": {
     "@types/jest": "^25.1.4",
     "@types/node": "12.x.x",
@@ -46,7 +49,6 @@
     "jest": "^25.2.4",
     "lint-staged": "^10.1.1",
     "memory-streams": "^0.1.3",
-    "p-graph": "^1.0.1",
     "prettier": "^2.0.2",
     "ts-jest": "^25.3.0",
     "typescript": "^3.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4451,10 +4451,10 @@ p-finally@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
   integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
-p-graph@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/p-graph/-/p-graph-1.0.1.tgz#86b698e2f3a97dc08862b57975e504038848b205"
-  integrity sha512-IssDuszsMWk8J/SJ9k7KVZIIE6/3Nw4joHMp+GnpztNPsWv8rsJm5i3zmXalPJmYLjYQYZCmhOZveuP0kunAzA==
+p-graph@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/p-graph/-/p-graph-1.0.2.tgz#79f6d2c6aff1c0c1a82c74dbd1fa076396c12e7b"
+  integrity sha512-BhJHTRrq48lZ7y/6NZu+t68N2lt+oe1H6rJaDnEqZJ+1D+wEmhMze12Yxyuy9MMxX1f928p8TiAvwUMzWwOdqg==
 
 p-is-promise@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
`p-graph` is used in `pipeline.ts` and is therefore
a `dependency`, not a `devDependency`.

Bump the version of `p-graph` from 1.0.1 to 1.0.2