### PR TITLE
Add error message for missing pipeline config

### DIFF
--- a/change/@microsoft-task-scheduler-2020-10-05-11-30-37-error.json
+++ b/change/@microsoft-task-scheduler-2020-10-05-11-30-37-error.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add error message for missing pipeline config",
+  "packageName": "@microsoft/task-scheduler",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-05T18:30:37.805Z"
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -101,7 +101,10 @@ export function createPipelineInternal(
             if (taskName === "") {
               packageTasks.set(taskId, { run: () => Promise.resolve() });
             } else {
-              const task = tasks.get(taskName)!;
+              const task = tasks.get(taskName);
+              if (!task) {
+                throw new Error(`Missing pipeline config for "${taskName}"`);
+              }
               packageTasks.set(taskId, {
                 priority: task.priorities && task.priorities[pkg],
                 run: () =>


### PR DESCRIPTION
If a pipeline specified a dependency name which is missing from the pipelines config, trying to run that pipeline would fail with `TypeError: Cannot read property 'priorities' of undefined`. Detect that case and explicitly throw an error with a helpful message instead.

(Debugging this issue was quite challenging due to the minified code, so it would be nice if the code was either not minified or some form of sourcemap was included.)